### PR TITLE
Initialize properties as arrays so the foreach doesn't break

### DIFF
--- a/lib/Nagios/Livestatus/Client.php
+++ b/lib/Nagios/Livestatus/Client.php
@@ -16,9 +16,9 @@ class Client
     protected $socket = null;
 
     protected $table = null;
-    protected $columns = null;
-    protected $filters = null;
-    protected $stats = null;
+    protected $columns = array();
+    protected $filters = array();
+    protected $stats = array();
 
     public function __construct(array $conf)
     {


### PR DESCRIPTION
The foreach loops around line 144 break when some properties are not defined and stay NULL instead of an array, which triggers a PHP warning.
