### PR TITLE
Fix socket path validation

### DIFF
--- a/lib/Nagios/Livestatus/Client.php
+++ b/lib/Nagios/Livestatus/Client.php
@@ -39,7 +39,7 @@ class Client
             if (strlen($this->socketPath) == 0) {
                 throw new InvalidArgumentException("The option socketPath must be supplied for socketType 'unix'");
             }
-            if (file_exists($this->socketPath) && is_readable($this->socketPath) && is_writable($this->socketPath)) {
+            if (!file_exists($this->socketPath) || !is_readable($this->socketPath) || !is_writable($this->socketPath)) {
                 throw new InvalidArgumentException("The supplied socketPath '{$this->socketPath}' is not accessible to this script.");
             }
             break;


### PR DESCRIPTION
The current validation will always fail if the socket exists and needed
to be an inverse of the current logic.

My guess is most people use TCP sockets which is why this was
never discovered.
