### PR TITLE
Add ability to supply raw query to execute()

### DIFF
--- a/lib/Nagios/Livestatus/Client.php
+++ b/lib/Nagios/Livestatus/Client.php
@@ -90,11 +90,19 @@ class Client
         return $this;
     }
 
-    public function execute()
+    public function execute($query = null)
     {
         $this->openSocket();
 
-        $query = $this->buildRequest();
+        // Check if query was supplied or needs to be built
+        if (is_null($query)) {
+            $query = $this->buildRequest();
+        }
+
+        // Add necessary data to query
+        $query .= "OutputFormat: json\n";
+        $query .= "ResponseHeader: fixed16\n";
+        $query .= "\n";
 
         // Send the query to MK Livestatus
         socket_write($this->socket, $query);
@@ -153,10 +161,6 @@ class Client
         foreach ($this->stats as $stat) {
             $request .= "Stats: " . $stat . "\n";
         }
-
-        $request .= "OutputFormat: json\n"
-            ."ResponseHeader: fixed16\n"
-            ."\n";
 
         return $request;
     }


### PR DESCRIPTION
This class can do a lot of the more common things but there are cases
where supplying a custom query to execute() is necessary. For example,
use of the 'And', 'Or' and 'Negate' provided by LQL is not really
possible.
