### PR TITLE
Add more flexibility and support more operations

### DIFF
--- a/lib/Nagios/Livestatus/Client.php
+++ b/lib/Nagios/Livestatus/Client.php
@@ -179,9 +179,7 @@ class Client
             return $this;
         }
 
-        $parameter = $this->checkEnding($parameter);
-
-        $this->query .= $parameter;
+        $this->query .= $this->checkEnding($parameter);
         return $this;
     }
 


### PR DESCRIPTION
Updated the library to be more flexible. There are times when order in
LQL matters very much. Adding to arrays and joining them at the end can
only take you so far.

This revamp adds in methods for many of the existing LQL operators
available and keeps order in tact.

There are probably some backward compatibility breaks in this revamped
code but hopefully only for things added by me in the last few weeks.

One thing that I was not able to figure out is how to create a method named `or`. This keeps getting interpreted as special code by PHP. In the interim I've named the method `lor` which is basically `logical or`. I'd love to make this better but not entirely sure how or if it is even possible.
