### PR TITLE
Add ability to put any parameter into query

### DIFF
--- a/lib/Nagios/Livestatus/Client.php
+++ b/lib/Nagios/Livestatus/Client.php
@@ -19,6 +19,7 @@ class Client
     protected $table = null;
     protected $columns = array();
     protected $filters = array();
+    protected $parameters = array();
     protected $stats = array();
 
     public function __construct(array $conf)
@@ -82,6 +83,12 @@ class Client
     public function filter($filter)
     {
         $this->filters[] = $filter;
+        return $this;
+    }
+
+    public function parameter($parameter)
+    {
+        $this->parameters[] = $parameter;
         return $this;
     }
 
@@ -159,6 +166,10 @@ class Client
             $request .= "Filter: " . $filter . "\n";
         }
 
+        foreach ($this->parameters as $parameter) {
+            $request .= $parameter . "\n";
+        }
+
         foreach ($this->stats as $stat) {
             $request .= "Stats: " . $stat . "\n";
         }
@@ -214,6 +225,7 @@ class Client
         $this->table = 'hosts';
         $this->columns = array();
         $this->filters = array();
+        $this->parameters = array();
         $this->stats = array();
     }
 


### PR DESCRIPTION
Add an OO way to put in any LQL parameter. See the following example:

$hosts = $client
    ->get("hostsbygroup")
    ->column("name")
    ->column("state")
    ->filter("state != 0")
    ->parameter("Filter: hostgroup = foo-hostgroup")
    ->parameter("Filter: hostgroup = bar-hostgroup")
    ->parameter("Or: 2")
    ->execute();

Being able to pass any query to execute() introduced in 35b25ce5 is nice
but being able to keep an OO mindset is even better when possible.
